### PR TITLE
Fix environment variables with `=`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ mkdir -p bin
 GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-X main.Version=dev+git" -o bin/kd_linux_amd64
 ```
 
+You can also build `kd` in a docker container:
+
+```bash
+docker run --rm -v $PWD:/go/src/github.com/UKHomeOffice/kd -w /go/src/github.com/UKHomeOffice/kd -ti golang:1.6 bash
+cd /go/src/UKHomeOffice/kd
+go get
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-X main.Version=dev+git" -o bin/kd_linux_amd64
+```
 
 ## Release process
 

--- a/tmpl.go
+++ b/tmpl.go
@@ -32,7 +32,7 @@ func render(r *ObjectResource, vars map[string]string, debug bool) error {
 func envToMap() map[string]string {
 	m := map[string]string{}
 	for _, n := range os.Environ() {
-		parts := strings.Split(n, "=")
+		parts := strings.SplitN(n, "=", 2)
 		m[parts[0]] = parts[1]
 	}
 	return m


### PR DESCRIPTION
At the moment it is not possibile to import environment variables that contain a `=`. This is particularly useful when variables are base64 encoded.

This PR fixes this issue.

Also, I added a note on how to compile kd inside a container.