### PR TITLE
Add output of template before talking to kubectl

### DIFF
--- a/main.go
+++ b/main.go
@@ -239,6 +239,9 @@ func deploy(c *cli.Context, r *ObjectResource) error {
 		return err
 	}
 	logInfo.Printf("deploying %s/%s", strings.ToLower(r.Kind), r.Name)
+	if c.Bool("debug") {
+		logDebug.Printf("Template:\n" + string(r.Template[:]))
+	}
 	if err = cmd.Run(); err != nil {
 		if errbuf.Len() > 0 {
 			return fmt.Errorf(errbuf.String())


### PR DESCRIPTION
You can't get the template output even with `--debug` if kubectl doesn't work e.g. kd output giving the following:
```
[ERROR] 2017/10/23 14:56:58 main.go:115: error: unable to recognize "STDIN": no matches for /, Kind=DaemonSet
```
Added the template output to allow for debugging the issue above.
