### PR TITLE
add support for watching jobs

### DIFF
--- a/types.go
+++ b/types.go
@@ -74,6 +74,8 @@ type DeploymentStatus struct {
 	UpdatedNumberScheduled int32 `yaml:"updatedNumberScheduled,omitempty"`
 	// End: Daemonset statuses
 
+	// Job Succeeded status
+	Succeeded int32 `yaml:"succeeded,omitempty"`
 }
 
 type ObjectSpec struct {


### PR DESCRIPTION
This will watch a Job that you deploy and either report that it succeeded or did not complete in the timeout period. Useful if you need to schedule jobs as part of a drone pipeline and don't want the pipeline to continue if the job failed. Could make this an optional flag if people don't want it to watch their job by default?