### PR TITLE
Allow kd to deploy specs larger than the pipe limit

### DIFF
--- a/main.go
+++ b/main.go
@@ -274,12 +274,11 @@ func deploy(c *cli.Context, r *ObjectResource) error {
 	cmd.Stdout = &outbuf
 	cmd.Stderr = &errbuf
 
-	if _, err := stdin.Write(r.Template); err != nil {
-		return err
-	}
-	if err := stdin.Close(); err != nil {
-		return err
-	}
+	go func() {
+		defer stdin.Close()
+		stdin.Write(r.Template)
+	}()
+
 	logInfo.Printf("deploying %s/%s", strings.ToLower(r.Kind), r.Name)
 	if err = cmd.Run(); err != nil {
 		if errbuf.Len() > 0 {


### PR DESCRIPTION
During a recent deployment a team attempted to deploy around 250 kB of Cronjobs in a List resource using kd. This works just fine with kubectl and after doing some spelunking we discovered an issue with the way in which kd pipes the template into kubectl. 

As the template is written into the pipe the pipe fills up. The capacity is around 64 kB on Linux and once that's reached the Write blocks indefinitely until the data is read from the pipe. Since the command is never run the pipe will never be flushed and it deadlocks.

To avoid this problem we setup a go routine to write to the pipe and kick off the command. Kubectl reads from the pipe and the goroutine writes until it runs out of bytes and then closes the pipe.
