### PR TITLE
Add download for CA

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,6 +26,14 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:18d3339287ed981065cbffedb0dc81196638666d04c83141e973a9bfad1be4a4"
+  name = "github.com/cavaliercoder/grab"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "466b5c0dd1d077be6de521d4e753734b17899a4d"
+  version = "v2.0.0"
+
+[[projects]]
   digest = "1:8f8811f9be822914c3a25c6a071e93beb4c805d7b026cbf298bc577bc1cc945b"
   name = "github.com/google/uuid"
   packages = ["."]
@@ -87,6 +95,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/Masterminds/sprig",
+    "github.com/cavaliercoder/grab",
     "github.com/joho/godotenv",
     "github.com/urfave/cli",
     "gopkg.in/yaml.v2",


### PR DESCRIPTION
- fix debug for subcommands

Testing (no CA):
```
~/go/src/github.com/UKHomeOffice/kd download_ca[]> ./bin/kd run get po
Unable to connect to the server: x509: certificate signed by unknown authority
[ERROR] 2018/07/24 09:26:20 main.go:195: error running 'kubectl get po' (use debug to see sensitive params):exit status 1
```
CA env = URL:
```
~/go/src/github.com/UKHomeOffice/kd download_ca[]> export KUBE_CERTIFICATE_AUTHORITY=http://localhost:8080/ca.crt
~/go/src/github.com/UKHomeOffice/kd download_ca[]> ./bin/kd run get po
NAME                                READY     STATUS    RESTARTS   AGE
nginx-deployment-75675f5897-cgm5c   1/1       Running   0          5d
nginx-deployment-75675f5897-fwpm7   1/1       Running   0          5d
nginx-deployment-75675f5897-g7mbl   1/1       Running   0          5d
~/go/src/github.com/UKHomeOffice/kd download_ca[]> ./bin/kd --debug=true run get po
[DEBUG] 2018/07/24 09:26:55 main.go:686: ca file specified as /tmp/kd156093487/kube-ca.pem, from http://localhost:8080/ca.crt
[DEBUG] 2018/07/24 09:26:55 main.go:245: About to run [kubectl --certificate-authority=/tmp/kd156093487/kube-ca.pem get po]
NAME                                READY     STATUS    RESTARTS   AGE
nginx-deployment-75675f5897-cgm5c   1/1       Running   0          5d
nginx-deployment-75675f5897-fwpm7   1/1       Running   0          5d
nginx-deployment-75675f5897-g7mbl   1/1       Running   0          5d
[DEBUG] 2018/07/24 09:26:55 main.go:202: cleaning up /tmp/kd156093487
```
CA file also set:
```
~/go/src/github.com/UKHomeOffice/kd download_ca[]> ./bin/kd --debug --certificate-authority-file /tmp/kube.pem run get po
[DEBUG] 2018/07/24 09:27:05 main.go:686: ca file specified as /tmp/kube.pem, from http://localhost:8080/ca.crt
[DEBUG] 2018/07/24 09:27:05 main.go:245: About to run [kubectl --certificate-authority=/tmp/kube.pem get po]
NAME                                READY     STATUS    RESTARTS   AGE
nginx-deployment-75675f5897-cgm5c   1/1       Running   0          5d
nginx-deployment-75675f5897-fwpm7   1/1       Running   0          5d
nginx-deployment-75675f5897-g7mbl   1/1       Running   0          5d
```
Finally - existing case - specify a file:
```
~/go/src/github.com/UKHomeOffice/kd download_ca[+]> export KUBE_CERTIFICATE_AUTHORITY=~/.minikube/ca.crt
~/go/src/github.com/UKHomeOffice/kd download_ca[+]> ./bin/kd run get po
NAME                                READY     STATUS    RESTARTS   AGE
nginx-deployment-75675f5897-cgm5c   1/1       Running   0          5d
nginx-deployment-75675f5897-fwpm7   1/1       Running   0          5d
nginx-deployment-75675f5897-g7mbl   1/1       Running   0          5d
```