### PR TITLE
#4528 - optionally allow missing values to be tolerated to make the S…

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,8 @@ const (
 	FlagReplace = "replace"
 	// FlagDelete indicates we are deleting the resources
 	FlagDelete = "delete"
+	// FlagAllowMissing indicates whether missing property values are allowed (replaced with <no value> if not provided)
+	FlagAllowMissing = "allow-missing"
 )
 
 var (
@@ -67,6 +69,9 @@ var (
 
 	// caFile
 	caFile string
+
+	// Allow missing variables to be tolerated
+	allowMissingVariables bool
 )
 
 func init() {
@@ -204,6 +209,11 @@ func main() {
 			EnvVar: "CHECK_INTERVAL,PLUGIN_CHECK_INTERVAL",
 			Value:  time.Duration(1000) * time.Millisecond,
 		},
+		cli.BoolFlag{
+			Name:   FlagAllowMissing,
+			Usage:  "if true, missing variables will be replaced with <no value> instead of generating an error",
+			EnvVar: "ALLOW_MISSING_FLAGS",
+		},
 	}
 	app.Commands = []cli.Command{
 		{
@@ -326,6 +336,10 @@ func run(c *cli.Context) error {
 		default:
 			files = append(files, fn)
 		}
+	}
+
+	if c.IsSet(FlagAllowMissing) {
+		allowMissingVariables = true
 	}
 
 	// Iterate the list of files and add rendered templates to resources list - fail early.

--- a/main.go
+++ b/main.go
@@ -212,7 +212,7 @@ func main() {
 		cli.BoolFlag{
 			Name:   FlagAllowMissing,
 			Usage:  "if true, missing variables will be replaced with <no value> instead of generating an error",
-			EnvVar: "ALLOW_MISSING_FLAGS",
+			EnvVar: "ALLOW_MISSING",
 		},
 	}
 	app.Commands = []cli.Command{

--- a/render.go
+++ b/render.go
@@ -39,7 +39,11 @@ func Render(k K8Api, tmpl string, vars map[string]string) (string, bool, error) 
 		}
 	}()
 	t := template.Must(template.New("template").Funcs(fm).Parse(tmpl))
-	t.Option("missingkey=error")
+	if allowMissingVariables {
+		t.Option("missingkey=default")
+	} else {
+		t.Option("missingkey=error")
+	}
 	var b bytes.Buffer
 	if err := t.Execute(&b, vars); err != nil {
 		return b.String(), secretUsed, err

--- a/test/file-with-calculations.yaml.template
+++ b/test/file-with-calculations.yaml.template
@@ -1,3 +1,5 @@
 something:
-  name: {{.NAME}}
-  port: {{add 10080 .OFFSET}}
+  name: {{ .NAME }}
+  port: {{ add 10080 .OFFSET }}
+  runAsUser: {{ .UID }}
+  runAsUserDefault: {{ default "1000" .UID }}

--- a/test/fileWith-prerendered.yaml
+++ b/test/fileWith-prerendered.yaml
@@ -1,1 +1,3 @@
 {{ fileWith .TEMPLATED_FILE_PATH (dict "NAME" "my-pod" "OFFSET" "3") }}
+region: "{{ .NOT_A_VALUE }}"
+regionDefault: "{{ default "eu-west-2" .NOT_A_VALUE }}"

--- a/test/fileWith-rendered.yaml
+++ b/test/fileWith-rendered.yaml
@@ -1,3 +1,7 @@
 something:
   name: my-pod
   port: 10083
+  runAsUser: <no value>
+  runAsUserDefault: 1000
+region: "<no value>"
+regionDefault: "eu-west-2"


### PR DESCRIPTION
…prig default function work.  Unable to test the original case in unit tests as recover() doesn't seem to work for Go templates.