### PR TITLE
Add jq to the kd container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 RUN apk upgrade --no-cache
-RUN apk add --no-cache ca-certificates openssl bash
+RUN apk add --no-cache ca-certificates openssl bash jq
 RUN update-ca-certificates
 
 RUN wget https://storage.googleapis.com/kubernetes-release/release/v1.19.13/bin/linux/amd64/kubectl \


### PR DESCRIPTION
This PR adds `jq` to the binaries installed in the `kd` container image.

Having `jq` installed in the `kd` image would allow the easy creation of config maps and secrets from key/value pairs stored in json strings. This is particularly useful when creating config maps and secrets from secrets stored in AWS Secrets Manager.

Examples:

```bash
# Store json key/value pairs in a file
$ cat <<EOF >data.json
{
  "foo": "bar",
  "baz": "wot"
}
EOF

# Use the json file to create a configmap
$ kd run create configmap my-config-map --from-env-file <(jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" data.json) --dry-run=client --output yaml
apiVersion: v1
data:
  baz: wot
  foo: bar
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: my-config-map
```

```bash
# Store json key/value pairs in an environment variable
export DATA='{"foo": "bar", "baz": "wot"}'

# Create a secret from the key/value pairs in the environment variable
$ kd run create secret generic my-secret --from-env-file <(jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" <(echo "${DATA}")) --dry-run=client --output yaml
apiVersion: v1
data:
  baz: d290
  foo: YmFy
kind: Secret
metadata:
  creationTimestamp: null
  name: my-secret
```
See [THIS](https://stackoverflow.com/questions/56060284/create-kubernetes-secret-from-json-file#56060487) answer on StackOverflow for reference.
