### PR TITLE
Remove use of Printf for rendered templates

### DIFF
--- a/main.go
+++ b/main.go
@@ -410,7 +410,7 @@ func run(c *cli.Context) error {
 	}
 	for _, r := range resources {
 		if c.Bool("debug-templates") {
-			logInfo.Printf("Template:\n" + string(r.Template[:]))
+			logInfo.Print("Template:\n" + string(r.Template[:]))
 		}
 		if err := yaml.Unmarshal(r.Template, &r); err != nil {
 			return err


### PR DESCRIPTION
Resolves an issue where templating is attempted for already rendered templates.